### PR TITLE
Feat/admin chat bubble separation

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -242,6 +242,7 @@ async def _merge_into_event(
         extracted_data=tool_data.model_dump(),
         location=point,
         location_text=tool_data.location_text,
+        geocoded_address=geocoded_address,
         event_id=target_event.id,
     )
     db.add(report)
@@ -317,6 +318,7 @@ async def _create_new_event(
         extracted_data=tool_data.model_dump(),
         location=point,
         location_text=tool_data.location_text,
+        geocoded_address=geocoded_address,
         event_id=event.id,
     )
     db.add(report)

--- a/frontend-admin/src/components/chat/ChatMessageView.tsx
+++ b/frontend-admin/src/components/chat/ChatMessageView.tsx
@@ -1,0 +1,23 @@
+import type { ChatMessage } from "../../types";
+
+interface ChatMessageViewProps {
+  message: ChatMessage;
+}
+
+function ChatMessageView({ message }: ChatMessageViewProps) {
+  const isUser = message.role === "user";
+
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[80%] rounded-lg px-4 py-2 text-sm ${
+          isUser ? "bg-red-600 text-white" : "bg-gray-100 text-gray-800"
+        }`}
+      >
+        <p className="whitespace-pre-wrap">{message.content}</p>
+      </div>
+    </div>
+  );
+}
+
+export default ChatMessageView;

--- a/frontend-admin/src/components/events/EventDetail.tsx
+++ b/frontend-admin/src/components/events/EventDetail.tsx
@@ -7,8 +7,10 @@ import {
   STATUS_LABELS,
 } from "../../types";
 import EventEditForm from "./EventEditForm";
+import ChatMessageView from "../chat/ChatMessageView";
 import { getEvents } from "../../services/api";
 import { formatBytes } from "../../utils/format";
+import { parseRawMessage } from "../../utils/parseRawMessage";
 
 interface EventDetailProps {
   event: DisasterEvent;
@@ -339,7 +341,21 @@ function EventDetail({ event, reports, onUpdate, onDelete, onMergeFrom }: EventD
                     <span>電話：{report.reporter_phone}</span>
                   )}
                 </div>
-                <p className="whitespace-pre-wrap text-sm">{report.raw_message}</p>
+                {(() => {
+                  const messages = parseRawMessage(report.raw_message);
+                  if (messages.length === 0) {
+                    return (
+                      <p className="whitespace-pre-wrap text-sm">{report.raw_message}</p>
+                    );
+                  }
+                  return (
+                    <div className="space-y-1">
+                      {messages.map((m, i) => (
+                        <ChatMessageView key={i} message={m} />
+                      ))}
+                    </div>
+                  );
+                })()}
                 {report.attachments && report.attachments.length > 0 && (
                   <div className="mt-2 flex flex-wrap gap-2">
                     {report.attachments.map((a) => (

--- a/frontend-admin/src/components/events/EventDetail.tsx
+++ b/frontend-admin/src/components/events/EventDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../types";
 import EventEditForm from "./EventEditForm";
 import { getEvents } from "../../services/api";
+import { formatBytes } from "../../utils/format";
 
 interface EventDetailProps {
   event: DisasterEvent;
@@ -327,12 +328,15 @@ function EventDetail({ event, reports, onUpdate, onDelete, onMergeFrom }: EventD
           <div className="space-y-3">
             {reports.map((report) => (
               <div key={report.id} className="rounded border p-3">
-                <div className="mb-1 flex items-center gap-2 text-xs text-gray-500">
+                <div className="mb-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
                   <span>
                     {new Date(report.created_at).toLocaleString("zh-TW")}
                   </span>
                   {report.reporter_name && (
                     <span>通報者：{report.reporter_name}</span>
+                  )}
+                  {report.reporter_phone && (
+                    <span>電話：{report.reporter_phone}</span>
                   )}
                 </div>
                 <p className="whitespace-pre-wrap text-sm">{report.raw_message}</p>
@@ -341,8 +345,8 @@ function EventDetail({ event, reports, onUpdate, onDelete, onMergeFrom }: EventD
                     {report.attachments.map((a) => (
                       <button
                         key={a.id}
-                        title={a.original_filename}
-                        className="block h-20 w-20 overflow-hidden rounded border bg-gray-100 hover:opacity-80"
+                        title={`${a.original_filename}（${formatBytes(a.size_bytes)}）`}
+                        className="block w-20 overflow-hidden rounded border bg-gray-100 text-left hover:opacity-80"
                         onClick={() => {
                           setLightboxImage(a);
                           setLightboxImages(report.attachments ?? []);
@@ -351,11 +355,22 @@ function EventDetail({ event, reports, onUpdate, onDelete, onMergeFrom }: EventD
                         <img
                           src={a.url}
                           alt={a.original_filename}
-                          className="h-full w-full object-cover"
+                          className="h-20 w-20 object-cover"
                         />
+                        <span className="block truncate px-1 py-0.5 text-[10px] text-gray-500">
+                          {formatBytes(a.size_bytes)}
+                        </span>
                       </button>
                     ))}
                   </div>
+                )}
+                {report.extracted_data && Object.keys(report.extracted_data).length > 0 && (
+                  <details className="mt-2 text-xs">
+                    <summary className="cursor-pointer text-gray-500">AI 提取欄位</summary>
+                    <pre className="mt-1 overflow-x-auto rounded bg-gray-50 p-2 text-[10px]">
+                      {JSON.stringify(report.extracted_data, null, 2)}
+                    </pre>
+                  </details>
                 )}
               </div>
             ))}

--- a/frontend-admin/src/utils/format.ts
+++ b/frontend-admin/src/utils/format.ts
@@ -1,0 +1,6 @@
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/frontend-admin/src/utils/parseRawMessage.ts
+++ b/frontend-admin/src/utils/parseRawMessage.ts
@@ -1,0 +1,34 @@
+import type { ChatMessage } from "../types";
+
+const ROLE_MARKER = /^\[(user|assistant)\][ \t]?/gm;
+
+export function parseRawMessage(raw: string): ChatMessage[] {
+  if (!raw) return [];
+
+  type Marker = { role: ChatMessage["role"]; start: number; end: number };
+  const markers: Marker[] = [];
+
+  ROLE_MARKER.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ROLE_MARKER.exec(raw)) !== null) {
+    markers.push({
+      role: match[1] as ChatMessage["role"],
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+
+  if (markers.length === 0) return [];
+
+  const messages: ChatMessage[] = [];
+  for (let i = 0; i < markers.length; i++) {
+    const contentStart = markers[i].end;
+    const contentEnd = i + 1 < markers.length ? markers[i + 1].start : raw.length;
+    const content = raw.slice(contentStart, contentEnd).trim();
+    if (content) {
+      messages.push({ role: markers[i].role, content });
+    }
+  }
+
+  return messages;
+}

--- a/frontend-mobile/src/components/chat/ReportSummaryView.tsx
+++ b/frontend-mobile/src/components/chat/ReportSummaryView.tsx
@@ -9,16 +9,26 @@ export function ReportSummaryView({ result }: Props) {
   const status = String(result.status ?? '');
   const message = String(result.message ?? '');
   const eventId = result.event_id ? String(result.event_id) : null;
-  const geocodedAddress = result.geocoded_address ? String(result.geocoded_address) : null;
+  const geocodedAddress = result.geocoded_address
+    ? String(result.geocoded_address)
+    : null;
+  const possibleDup = result.possible_duplicate_event_id
+    ? String(result.possible_duplicate_event_id)
+    : null;
 
   const isSuccess = status === 'created' || status === 'merged';
 
   return (
     <View style={[styles.box, isSuccess ? styles.boxSuccess : styles.boxError]}>
-      <Text style={styles.title}>{isSuccess ? '✓ 通報已送出' : '⚠ 通報處理'}</Text>
+      <Text style={styles.title}>
+        {isSuccess ? '✓ 通報已送出' : '⚠ 通報處理'}
+      </Text>
       <Text style={styles.message}>{message || status}</Text>
       {geocodedAddress && (
         <Text style={styles.meta}>地點：{geocodedAddress}</Text>
+      )}
+      {possibleDup && (
+        <Text style={styles.warn}>⚠ 偵測到可能與另一筆通報重複</Text>
       )}
       {eventId && <Text style={styles.meta}>事件 ID：{eventId}</Text>}
     </View>
@@ -38,4 +48,5 @@ const styles = StyleSheet.create({
   title: { fontSize: 15, fontWeight: '700', marginBottom: 4, color: '#111827' },
   message: { fontSize: 14, color: '#374151', lineHeight: 20 },
   meta: { fontSize: 12, color: '#6b7280', marginTop: 4 },
+  warn: { fontSize: 12, color: '#b45309', marginTop: 4 },
 });

--- a/frontend-public/src/components/chat/ReportSummary.tsx
+++ b/frontend-public/src/components/chat/ReportSummary.tsx
@@ -1,5 +1,11 @@
 function ReportSummary({ result }: { result: Record<string, unknown> }) {
   const isNew = result.status === "created";
+  const geocoded = result.geocoded_address
+    ? String(result.geocoded_address)
+    : null;
+  const possibleDup = result.possible_duplicate_event_id
+    ? String(result.possible_duplicate_event_id)
+    : null;
 
   return (
     <div
@@ -16,6 +22,14 @@ function ReportSummary({ result }: { result: Record<string, unknown> }) {
         </span>
       </div>
       <p className="text-sm text-gray-700">{result.message as string}</p>
+      {geocoded && (
+        <p className="mt-2 text-xs text-gray-600">地點：{geocoded}</p>
+      )}
+      {possibleDup && (
+        <p className="mt-1 text-xs text-amber-700">
+          ⚠ 系統偵測到可能與另一筆通報重複
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
本次拉取請求對後端和前端都進行了多項改進，重點在於增強聊天訊息的顯示和解析、改進報告詳情的呈現方式，以及更好地處理地理編碼地址和重複事件檢測。具體改進包括：後端支援在報告中儲存地理編碼位址；新增用於解析聊天訊息格式的實用程式；增強事件和報告詳情的使用者介面；以及提供更清晰的使用者回饋，提示可能存在的重複報告。

**前端報告和聊天顯示的增強：**

* 新增了 `ChatMessageView` 元件和 `parseRawMessage` 公用程序，用於解析和渲染報告詳情中的聊天式訊息，從而提升管理介面中原始訊息的可讀性和結構性。 (`frontend-admin/src/components/chat/ChatMessageView.tsx`, `frontend-admin/src/utils/parseRawMessage.ts`, `frontend-admin/src/components/events/EventDetail.tsx`) [[1]](diffhunk://#diff-d7d01b8b5978ea8c6a7f23d7e79096ba4895aa0a16cfe04bcd455bbf2f82e8edR1-R23) [[2]](diffhunk://#diff-6f0b34b863f31df4df9e7f79abbab3ac8204360ddce6990ee0e05b366590804eR1-R34) [[3]](diffhunk://#diff-d7a7e43cdcdb06d287aadae287c3f06f71268ed30c6c1578585117b37a891257L330-R365)

* 透過使用新的 `formatBytes` 公用程式顯示檔案大小，增強了報表附件的顯示效果，提高了附件資訊的清晰度。 (`frontend-admin/src/utils/format.ts`, `frontend-admin/src/components/events/EventDetail.tsx`) [[1]](diffhunk://#diff-975d7afc738075f3142d24f4cf81e678d9c4672b257020be1dabb2625576cac9R1-R6) [[2]](diffhunk://#diff-d7a7e43cdcdb06d287aadae287c3f06f71268ed30c6c1578585117b37a891257L330-R365) [[3]](diffhunk://#diff-d7a7e43cdcdb06d287aadae287c3f06f71268ed30c6c1578585117b37a891257L354-R390)

* 新增了一個可折疊部分，用於顯示從報告中提取的 AI 字段，使結構化資料在管理介面中更易於存取。 (`frontend-admin/src/components/events/EventDetail.tsx`)

**報告資料後端改善：**

* 更新了後端端點，以便在合併或建立新事件時將 `geocoded_address` 儲存在報表中，確保地址資訊始終可用於前端顯示。 (`backend/app/api/chat.py`) [[1]](diffhunk://#diff-0ef687668c5fcd2d6d3a7ac46ca6541c617819bb6a68b1350dc07b579674a2R24bb6a68b1350dc07b579674a2R24bb6a68b1350dcfb5) [[2]](diffhunk://#diff-0ef687668c5fcd2d6d3a7ac46ca6541c617819bb6a68b1350dfbc07b579674a2R321)

**使用者回饋與重複偵測：**

* 更新了管理員和公共/行動裝置報告摘要元件，以顯示地理編碼位址，並在偵測到可能的重複事件時通知用戶，從而提供更清晰的回饋並減少重複條目。 (`frontend-mobile/src/components/chat/ReportSummaryView.tsx`, `frontend-public/src/components/chat/ReportSummary.tsx`) [[1]](diffhunk://#diff-12e47b8bbe2f5292d4f68adfa91f802db84c520e83fdebf52cfd667f3088c000L12-R32) [[2]](diffhunk://#diff-12e47b8bbe2f5292d4f68adfa91f802db84c520e83fdebf52cfd667f3088c000R51) [[3]](diffhunk://#diff-b30f574460d9b5c1893634262635ce455c82cd3f6d4433d3b837dee0f229c9efR3-R8) [[4]](diffhunk://#diff-b30f574460d9b5c1893634262635ce455c82cd3f6d4433d3b837dee0f229c9efR25-R32)